### PR TITLE
Do not update_option for DB version on every request

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -19,7 +19,11 @@ class WP_Auth0_DBManager
 			$current_ver = (int) get_site_option('auth0_db_version', 0);
 		}
 
-		if (empty($current_ver) || $current_ver === AUTH0_DB_VERSION) {
+		if ($current_ver === AUTH0_DB_VERSION) {
+			return;
+		}
+
+		if (empty($current_ver)) {
 			update_option('auth0_db_version', AUTH0_DB_VERSION);
 			return;
 		}


### PR DESCRIPTION
The install_db function is hooked into the plugins loaded action, but includes an `update_option` call which is fired even when the stored option DOES match.

This is inefficient, and can cause unnecessary DB write load. It is especially problematic on some enterprise hosting where an UPDATE call causes all subsequent reads in a request to go through a Writer database instead of a read replica, overwhelming production DB servers.